### PR TITLE
Add automatic dependency installation to launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ python main.py
 python -m thermal_delam_detector.app
 ```
 
-Both commands call the same `launch()` function that builds the GUI and starts the mainloop. When the window opens:
+Both commands call the same `launch()` function that builds the GUI and starts the mainloop. The `main.py` entry point will
+automatically install required Python dependencies (``Pillow`` and ``numpy``) and will attempt to install the optional
+``tkinterdnd2`` package for drag-and-drop support, making it a one-stop launch script. When the window opens:
 
 1. Drop a folder of RJPG/JPEG/TIFF thermal images onto the window or choose it via the **Browse** button.
 2. Adjust the percentile, minimum hotspot size, and morphology sliders until the preview looks right.

--- a/main.py
+++ b/main.py
@@ -1,10 +1,64 @@
-"""Application entry point for launching the GUI."""
+"""Application entry point for launching the GUI with automatic dependency setup."""
 from __future__ import annotations
 
-from thermal_delam_detector.app import launch
+import importlib
+import subprocess
+import sys
+from typing import Mapping
+
+
+_REQUIRED_DEPENDENCIES: Mapping[str, str] = {
+    "PIL": "Pillow",
+    "numpy": "numpy",
+}
+
+_OPTIONAL_DEPENDENCIES: Mapping[str, str] = {
+    "tkinterdnd2": "tkinterdnd2",
+}
+
+
+def _ensure_module(module_name: str, package_name: str, *, required: bool) -> None:
+    """Ensure ``module_name`` can be imported, installing ``package_name`` if needed."""
+
+    try:
+        importlib.import_module(module_name)
+    except ModuleNotFoundError:
+        message = (
+            f"Installing required dependency: {package_name}"
+            if required
+            else f"Installing optional dependency: {package_name}"
+        )
+        print(message, file=sys.stderr)
+        try:
+            subprocess.check_call([sys.executable, "-m", "pip", "install", package_name])
+        except subprocess.CalledProcessError as exc:
+            if required:
+                raise SystemExit(
+                    f"Failed to install required dependency '{package_name}'."
+                ) from exc
+            print(
+                f"Warning: optional dependency '{package_name}' could not be installed.",
+                file=sys.stderr,
+            )
+        else:
+            importlib.invalidate_caches()
+            importlib.import_module(module_name)
+
+
+def ensure_dependencies() -> None:
+    """Install missing dependencies so the application is ready to launch."""
+
+    for module_name, package_name in _REQUIRED_DEPENDENCIES.items():
+        _ensure_module(module_name, package_name, required=True)
+
+    for module_name, package_name in _OPTIONAL_DEPENDENCIES.items():
+        _ensure_module(module_name, package_name, required=False)
 
 
 def main() -> None:
+    ensure_dependencies()
+    from thermal_delam_detector.app import launch
+
     launch()
 
 


### PR DESCRIPTION
## Summary
- add dependency bootstrap logic to `main.py` so required packages are installed before launching the GUI
- document the one-stop dependency setup behaviour in the README

## Testing
- python -m compileall main.py thermal_delam_detector

------
https://chatgpt.com/codex/tasks/task_b_68e4018cb600832f86f7620f5f659b88