### PR TITLE
Clarify headless usage when Tk display fails

### DIFF
--- a/thermal_delam_detector/app.py
+++ b/thermal_delam_detector/app.py
@@ -835,7 +835,10 @@ def launch() -> None:
         message = (
             "The graphical interface could not be started because Tk was unable to initialise. "
             "Ensure that a display server is available (for example by setting the DISPLAY "
-            "environment variable) before launching the application."
+            "environment variable) before launching the application.\n\n"
+            "If you are running the tool on a headless machine, launch the batch processor instead "
+            "with `python main.py --input <folder-with-images>` (optionally add --output to choose "
+            "the destination)."
         )
         _show_dependency_error("Display unavailable", message)
         raise SystemExit(1) from exc


### PR DESCRIPTION
## Summary
- expand the GUI launch error message to describe how to run the batch processor when no display is available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e406ca4828832f89093d6555fe0b8d