### PR TITLE
Ensure --force-gui flag bypasses display availability check

### DIFF
--- a/main.py
+++ b/main.py
@@ -195,7 +195,7 @@ def main(argv: Sequence[str] | None = None) -> None:
 
     from thermal_delam_detector.app import launch
 
-    launch()
+    launch(force_gui=args.force_gui)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/thermal_delam_detector/app.py
+++ b/thermal_delam_detector/app.py
@@ -855,7 +855,7 @@ def _format_dependency_message(exc: ModuleNotFoundError) -> str:
     )
 
 
-def launch() -> None:
+def launch(*, force_gui: bool = False) -> None:
     if _PIL_IMPORT_ERROR is not None:
         message = _format_dependency_message(_PIL_IMPORT_ERROR)
         _show_dependency_error("Missing dependency", message)
@@ -866,7 +866,7 @@ def launch() -> None:
         _show_dependency_error("Missing dependency", message)
         raise SystemExit(1) from _DEPENDENCY_ERROR
 
-    if not _display_available():
+    if not force_gui and not _display_available():
         message = (
             "The graphical interface could not be started because Tk was unable to initialise. "
             "Ensure that a display server is available (for example by setting the DISPLAY "


### PR DESCRIPTION
## Summary
- allow the GUI launcher to accept a force flag so it can skip the display probe when explicitly requested
- update the CLI entry point to pass the force flag through to the GUI launcher

## Testing
- python -m compileall main.py thermal_delam_detector

------
https://chatgpt.com/codex/tasks/task_b_68e40c090594832f8946e2828b69ea5e