### PR TITLE
Assume Windows desktop display when launching GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Both commands call the same `launch()` function that builds the GUI and starts t
 automatically install required Python dependencies (``Pillow`` and ``numpy``) and will attempt to install the optional
 ``tkinterdnd2`` package for drag-and-drop support, making it a one-stop launch script. When the window opens:
 
+> **Windows users:** The launcher assumes a graphical desktop is present, so you can simply run `python main.py` (or `py -3 main.py`) and the GUI will open. There is no need to set a `DISPLAY` environment variable on Windows; just ensure your Python installation includes the optional Tcl/Tk components.
+
 1. Drop a folder of RJPG/JPEG/TIFF thermal images onto the window or choose it via the **Browse** button.
 2. Adjust the percentile, minimum hotspot size, and morphology sliders until the preview looks right.
 3. Click **Process images** to export annotated overlays to the selected output folder (defaults to `<input>/processed`).

--- a/main.py
+++ b/main.py
@@ -109,11 +109,21 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 def _display_available() -> bool:
     """Return ``True`` if Tk can successfully open a display."""
 
+    # Windows bundles an embedded display server with Tk, so if ``tkinter`` can
+    # be imported we assume the GUI can launch without probing further. Creating
+    # a root window is still safe on Windows, but skipping it avoids spurious
+    # ``TclError`` exceptions on systems where the display is available yet Tk
+    # momentarily fails to initialise during the probe (for example when Python
+    # starts before the shell session is ready). Other platforms still create a
+    # temporary root window to confirm that Tk can talk to the system display.
     try:
         import tkinter as tk
     except ModuleNotFoundError:
         # Tk is not available, so launching the GUI would fail.
         return False
+
+    if sys.platform.startswith("win"):
+        return True
 
     try:
         root = tk.Tk()

--- a/thermal_delam_detector/app.py
+++ b/thermal_delam_detector/app.py
@@ -802,6 +802,10 @@ def _display_available() -> bool:
     if _DISPLAY_AVAILABLE is not None:
         return _DISPLAY_AVAILABLE
 
+    if sys.platform.startswith("win"):
+        _DISPLAY_AVAILABLE = True
+        return _DISPLAY_AVAILABLE
+
     try:
         root = tk.Tk()
     except tk.TclError:
@@ -869,8 +873,9 @@ def launch(*, force_gui: bool = False) -> None:
     if not force_gui and not _display_available():
         message = (
             "The graphical interface could not be started because Tk was unable to initialise. "
-            "Ensure that a display server is available (for example by setting the DISPLAY "
-            "environment variable) before launching the application.\n\n"
+            "Ensure that a display server is available (for example an X/Wayland session on Linux "
+            "or the default Windows desktop) before launching the application. On Windows make "
+            "sure that Python was installed with the optional Tcl/Tk components.\n\n"
             "If you are running the tool on a headless machine, launch the batch processor instead "
             "with `python main.py --input <folder-with-images>` (optionally add --output to choose "
             "the destination)."
@@ -885,8 +890,9 @@ def launch(*, force_gui: bool = False) -> None:
     except tk.TclError as exc:  # pragma: no cover - depends on runtime environment
         message = (
             "The graphical interface could not be started because Tk was unable to initialise. "
-            "Ensure that a display server is available (for example by setting the DISPLAY "
-            "environment variable) before launching the application.\n\n"
+            "Ensure that a display server is available (for example an X/Wayland session on Linux "
+            "or the default Windows desktop) before launching the application. On Windows make "
+            "sure that Python was installed with the optional Tcl/Tk components.\n\n"
             "If you are running the tool on a headless machine, launch the batch processor instead "
             "with `python main.py --input <folder-with-images>` (optionally add --output to choose "
             "the destination)."


### PR DESCRIPTION
## Summary
- treat Windows environments as display-capable when launching the GUI to avoid false negative display checks
- update user-facing error text to mention Windows-specific guidance for missing Tk installations
- document in the README that Windows users can launch the GUI directly without DISPLAY configuration

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_b_68e410d51114832fac78a5b168fe5e31