### PR TITLE
Restore GUI-only launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,26 +50,9 @@ launch the application again.
 2. Adjust the percentile, minimum hotspot size, and morphology sliders until the preview looks right.
 3. Click **Process images** to export annotated overlays to the selected output folder (defaults to `<input>/processed`).
 
-### Running without a display
-
-If you are on a headless environment where Tk cannot initialise (for example a remote server without an X/Wayland session),
-the `main.py` entry point also exposes a batch-processing mode. Provide an input directory containing supported images and the
-tool will save processed overlays to `<input>/processed` (or a custom output directory via `--output`):
-
-```bash
-python main.py --input /path/to/images --output /path/to/output
-```
-
-Additional optional flags mirror the GUI controls:
-
-- `--hotspot-percentile` – adjust the percentile threshold (default `97`).
-- `--min-cluster-size` – minimum hotspot size in pixels (default `45`).
-- `--opening-iterations` / `--closing-iterations` – morphological cleanup iterations (default `1`).
-- `--kernel-size` – kernel size for the morphology operations (default `3`).
-
-When no display is detected and `--input` is omitted the script now drops into an interactive console workflow that walks you
-through selecting folders and adjusting processing parameters. This makes it possible to use the tool even on servers accessed
-via SSH. Pass `--force-gui` to override the display check when you know a display server is available.
+The launcher is designed for use on machines with an available graphical display. If Tk cannot initialise (for example,
+because Python was installed without Tcl/Tk), the script will display a descriptive error message so the issue can be
+resolved before relaunching.
 
 ## Automating the processing pipeline
 

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-"""Application entry point for launching the GUI with automatic dependency setup."""
+"""Application entry point for launching the Thermal Delamination Detector GUI."""
 from __future__ import annotations
 
 import argparse
@@ -7,8 +7,8 @@ import os
 import subprocess
 import sys
 import sysconfig
-from pathlib import Path
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Mapping, Sequence
 
 
@@ -156,44 +156,7 @@ def ensure_dependencies() -> None:
 
 def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Thermal Delamination Detector GUI and command-line entry point.",
-    )
-    parser.add_argument(
-        "--input",
-        "-i",
-        type=Path,
-        help="Folder containing RJPG/JPEG/TIFF images to process in headless mode.",
-    )
-    parser.add_argument(
-        "--output",
-        "-o",
-        type=Path,
-        help="Destination folder for processed overlays (defaults to '<input>/processed').",
-    )
-    parser.add_argument(
-        "--hotspot-percentile",
-        type=float,
-        help="Percentile used to detect hotspots (default 97).",
-    )
-    parser.add_argument(
-        "--min-cluster-size",
-        type=int,
-        help="Minimum hotspot size in pixels (default 45).",
-    )
-    parser.add_argument(
-        "--opening-iterations",
-        type=int,
-        help="Number of morphological opening iterations (default 1).",
-    )
-    parser.add_argument(
-        "--closing-iterations",
-        type=int,
-        help="Number of morphological closing iterations (default 1).",
-    )
-    parser.add_argument(
-        "--kernel-size",
-        type=int,
-        help="Kernel size for morphological operations (odd integer, default 3).",
+        description="Thermal Delamination Detector GUI entry point.",
     )
     parser.add_argument(
         "--force-gui",
@@ -207,7 +170,6 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 class _DisplayStatus:
     available: bool
     error: str | None = None
-    display_connection_issue: bool = False
 
 
 def _display_status() -> _DisplayStatus:
@@ -234,11 +196,6 @@ def _display_status() -> _DisplayStatus:
         )
 
     if sys.platform.startswith("win"):
-        # When Tkinter imports successfully on Windows we normally assume a display
-        # is available. However, some minimal Python builds ship the ``tkinter``
-        # package without the native Tcl/Tk DLLs. Importing succeeds but creating a
-        # root window raises ``TclError`` immediately. Probing for a root window lets
-        # us surface that specific failure mode with a clearer message.
         try:
             root = tk.Tk()
         except tk.TclError as exc:
@@ -266,7 +223,6 @@ def _display_status() -> _DisplayStatus:
                 "session is running and that the DISPLAY environment variable is "
                 f"set correctly. Underlying error: {exc}"
             ),
-            display_connection_issue=True,
         )
     else:
         root.withdraw()
@@ -274,280 +230,17 @@ def _display_status() -> _DisplayStatus:
         return _DisplayStatus(available=True)
 
 
-def _run_cli(args: argparse.Namespace) -> None:
-    from thermal_delam_detector.io_utils import (
-        discover_images,
-        ensure_output_folder,
-        save_with_metadata,
-    )
-    from thermal_delam_detector.processing import ImageProcessor
-
-    if args.input is None:
-        raise SystemExit("Input folder must be provided when running headlessly.")
-
-    input_folder = args.input.expanduser().resolve()
-    if not input_folder.exists() or not input_folder.is_dir():
-        raise SystemExit(f"Input folder does not exist or is not a directory: {input_folder}")
-
-    output_folder = ensure_output_folder(
-        input_folder,
-        args.output.expanduser().resolve() if args.output else None,
-    )
-
-    processor = ImageProcessor()
-    config_updates = {}
-    if args.hotspot_percentile is not None:
-        config_updates["hotspot_percentile"] = args.hotspot_percentile
-    if args.min_cluster_size is not None:
-        config_updates["min_cluster_size"] = args.min_cluster_size
-    if args.opening_iterations is not None:
-        config_updates["opening_iterations"] = args.opening_iterations
-    if args.closing_iterations is not None:
-        config_updates["closing_iterations"] = args.closing_iterations
-    if args.kernel_size is not None:
-        config_updates["kernel_size"] = args.kernel_size
-    if config_updates:
-        processor.update_config(**config_updates)
-
-    images = list(discover_images(input_folder))
-    if not images:
-        raise SystemExit(
-            f"No supported images were found in: {input_folder}. Supported extensions: .rjpg, .jpg, .jpeg, .tif, .tiff"
-        )
-
-    processed = 0
-    for image_path in images:
-        result = processor.process_image(image_path)
-        destination = output_folder / f"{image_path.stem}_processed.jpg"
-        save_with_metadata(result.overlay_image, destination, result.exif_bytes)
-        processed += 1
-        print(f"Processed {image_path.name} -> {destination}")
-
-    print(
-        f"Finished processing {processed} image(s). Annotated overlays saved to: {output_folder}"
-    )
-
-
-def _maybe_prompt_for_input(args: argparse.Namespace) -> argparse.Namespace | None:
-    """Request an input folder interactively when running headlessly.
-
-    In GUI mode the user can choose a folder from the interface. When no display
-    is available we provide a small console prompt so the tool remains usable in
-    terminal-only environments. Returning ``None`` signals that no interactive
-    input could be obtained and the program should fall back to the standard
-    error message.
-    """
-
-    if args.input is not None:
-        return args
-
-    if not sys.stdin.isatty():
-        return None
-
-    print(
-        "No graphical display detected. Enter the path to the folder containing "
-        "images to process (leave blank to cancel)."
-    )
-
-    while True:
-        try:
-            response = input("Input folder: ").strip()
-        except EOFError:
-            return None
-
-        if not response:
-            print("No folder provided. Exiting.")
-            return None
-
-        candidate = Path(response).expanduser().resolve()
-        if candidate.exists() and candidate.is_dir():
-            args.input = candidate
-            return args
-
-        print(f"Folder does not exist or is not a directory: {candidate}")
-
-
-def _interactive_headless_session(args: argparse.Namespace) -> argparse.Namespace | None:
-    """Guide the user through configuring a batch run when no GUI is available."""
-
-    if not sys.stdin.isatty():
-        return None
-
-    from thermal_delam_detector.processing import ImageProcessor
-
-    processor = ImageProcessor()
-
-    print(
-        "\nA graphical environment was not detected. Switching to the interactive "
-        "console workflow so the Thermal Delamination Detector can still be used."
-    )
-    print("Press Ctrl+C at any prompt to cancel. Leave an entry blank to accept the default.")
-
-    def _prompt_path(prompt: str, *, must_exist: bool) -> Path | None:
-        while True:
-            try:
-                response = input(prompt).strip()
-            except (EOFError, KeyboardInterrupt):
-                print("\nOperation cancelled.")
-                raise SystemExit(1)
-
-            if not response:
-                return None
-
-            candidate = Path(response).expanduser().resolve()
-            if not must_exist:
-                return candidate
-
-            if candidate.exists() and candidate.is_dir():
-                return candidate
-
-            print(f"Folder does not exist or is not a directory: {candidate}")
-
-    def _prompt_float(prompt: str, default: float) -> float:
-        while True:
-            try:
-                response = input(f"{prompt} [{default}]: ").strip()
-            except EOFError:
-                return default
-            except KeyboardInterrupt:
-                print("\nOperation cancelled.")
-                raise SystemExit(1)
-
-            if not response:
-                return default
-
-            try:
-                value = float(response)
-            except ValueError:
-                print("Please enter a valid number.")
-                continue
-
-            return value
-
-    def _prompt_int(prompt: str, default: int, *, allow_zero: bool = False) -> int:
-        while True:
-            try:
-                response = input(f"{prompt} [{default}]: ").strip()
-            except EOFError:
-                return default
-            except KeyboardInterrupt:
-                print("\nOperation cancelled.")
-                raise SystemExit(1)
-
-            if not response:
-                return default
-
-            try:
-                value = int(response)
-            except ValueError:
-                print("Please enter an integer value.")
-                continue
-
-            if value <= 0 and not allow_zero:
-                print("Please enter a positive integer.")
-                continue
-
-            return value
-
-    input_folder = None
-    while input_folder is None:
-        input_folder = _prompt_path("Input folder path: ", must_exist=True)
-        if input_folder is None:
-            print("Input folder is required to continue.")
-            continue
-    output_folder = _prompt_path(
-        "Output folder (leave blank to use '<input>/processed'): ", must_exist=False
-    )
-
-    hotspot = _prompt_float(
-        "Hotspot percentile", processor.config.hotspot_percentile
-    )
-    min_cluster = _prompt_int(
-        "Minimum cluster size (pixels)", processor.config.min_cluster_size
-    )
-    opening = _prompt_int(
-        "Opening iterations", processor.config.opening_iterations, allow_zero=True
-    )
-    closing = _prompt_int(
-        "Closing iterations", processor.config.closing_iterations, allow_zero=True
-    )
-
-    def _prompt_kernel(default: int) -> int:
-        while True:
-            value = _prompt_int("Kernel size (odd integer)", default)
-            if value % 2 == 1:
-                return value
-            print("Kernel size must be an odd integer.")
-
-    kernel_size = _prompt_kernel(processor.config.kernel_size)
-
-    updated = argparse.Namespace(**vars(args))
-    updated.input = input_folder
-    updated.output = output_folder
-    updated.hotspot_percentile = hotspot
-    updated.min_cluster_size = min_cluster
-    updated.opening_iterations = opening
-    updated.closing_iterations = closing
-    updated.kernel_size = kernel_size
-
-    print("\nConfiguration summary:")
-    print(f"  Input folder : {input_folder}")
-    print(
-        "  Output folder: "
-        + (str(output_folder) if output_folder is not None else "<input>/processed")
-    )
-    print(f"  Hotspot percentile  : {hotspot}")
-    print(f"  Minimum cluster size: {min_cluster}")
-    print(f"  Opening iterations  : {opening}")
-    print(f"  Closing iterations  : {closing}")
-    print(f"  Kernel size         : {kernel_size}")
-
-    try:
-        proceed = input("\nProceed with processing? [Y/n]: ").strip().lower()
-    except (EOFError, KeyboardInterrupt):
-        print("\nOperation cancelled.")
-        raise SystemExit(1)
-
-    if proceed not in {"", "y", "yes"}:
-        print("Processing aborted at user request.")
-        raise SystemExit(0)
-
-    return updated
-
-
 def main(argv: Sequence[str] | None = None) -> None:
     args = _parse_args(argv)
     ensure_dependencies()
 
-    if args.input is not None:
-        _run_cli(args)
-        return
-
     display_status = _display_status()
     if not args.force_gui and not display_status.available:
-        prompted_args = _maybe_prompt_for_input(args)
-        if prompted_args is not None and prompted_args.input is not None:
-            _run_cli(prompted_args)
-            return
-
-        interactive_args = _interactive_headless_session(args)
-        if interactive_args is not None and interactive_args.input is not None:
-            _run_cli(interactive_args)
-            return
-
         message = [
             "The graphical interface could not be started because Tk was unable to initialise.",
-            "A console-based workflow could not be started automatically (no interactive "
-            "terminal was detected).",
         ]
         if display_status.error:
             message.append(display_status.error)
-        if display_status.display_connection_issue:
-            message.append(
-                "If you are running the tool on a headless machine, launch the batch processor "
-                "instead with 'python main.py --input <folder-with-images>' (optionally add "
-                "'--output' to choose the destination)."
-            )
         raise SystemExit("\n".join(message))
 
     from thermal_delam_detector.app import launch

--- a/thermal_delam_detector/app.py
+++ b/thermal_delam_detector/app.py
@@ -875,11 +875,7 @@ def launch(*, force_gui: bool = False) -> None:
             "The graphical interface could not be started because Tk was unable to initialise. "
             "Ensure that a display server is available (for example an X/Wayland session on Linux "
             "or the default Windows desktop) before launching the application. On Windows make "
-            "sure that Python was installed with the optional Tcl/Tk components.\n\n"
-            "When no display is available the application now falls back to an interactive "
-            "console workflow. Run `python main.py` from a terminal to follow the prompts, or "
-            "launch the batch processor directly with `python main.py --input <folder-with-images>` "
-            "(optionally add --output to choose the destination)."
+            "sure that Python was installed with the optional Tcl/Tk components."
         )
         _show_dependency_error(
             "Display unavailable", message, display_available=False
@@ -893,11 +889,7 @@ def launch(*, force_gui: bool = False) -> None:
             "The graphical interface could not be started because Tk was unable to initialise. "
             "Ensure that a display server is available (for example an X/Wayland session on Linux "
             "or the default Windows desktop) before launching the application. On Windows make "
-            "sure that Python was installed with the optional Tcl/Tk components.\n\n"
-            "When no display is available the application now falls back to an interactive "
-            "console workflow. Run `python main.py` from a terminal to follow the prompts, or "
-            "launch the batch processor directly with `python main.py --input <folder-with-images>` "
-            "(optionally add --output to choose the destination)."
+            "sure that Python was installed with the optional Tcl/Tk components."
         )
         _show_dependency_error("Display unavailable", message)
         raise SystemExit(1) from exc


### PR DESCRIPTION
## Summary
- remove the headless command-line paths from `main.py` so it always launches the GUI
- update the GUI error messaging to focus on display availability rather than console fallbacks
- refresh the README to remove headless usage instructions and emphasise GUI launch requirements

## Testing
- python -m compileall main.py thermal_delam_detector/app.py

------
https://chatgpt.com/codex/tasks/task_b_68e422489a3c832f8ffb37de614e9ec8